### PR TITLE
Fix wallpaper path handling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,10 +12,10 @@ fi
 CURRENT_WP_PATH=$(cat ~/.config/plasma-org.kde.plasma.desktop-appletsrc | grep -E "^Image=(file)?" | sed -E 's/Image=(file:\/\/)?//')
 
 if ! test -f ~/.bg.png; then
-    if [ $CURRENT_WP_PATH ]; then
+    if [ "$CURRENT_WP_PATH" ]; then
         echo blurring your current wallpaper
         echo
-        convert $CURRENT_WP_PATH -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
+        convert "$CURRENT_WP_PATH" -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
         sleep 10
     else
         PROMPT=1

--- a/wpblur.sh
+++ b/wpblur.sh
@@ -8,6 +8,6 @@ fi
 while true; do
     inotifywait -q ~/.config/plasma-org.kde.plasma.desktop-appletsrc -e delete_self -e open | while read; do
         sleep 2
-        convert $(cat ~/.config/plasma-org.kde.plasma.desktop-appletsrc | grep -E "^Image=(file)?" | sed -E 's/Image=(file:\/\/)?//') -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
+        convert "$(cat ~/.config/plasma-org.kde.plasma.desktop-appletsrc | grep -E "^Image=(file)?" | sed -E 's/Image=(file:\/\/)?//')" -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
     done
 done


### PR DESCRIPTION
If there's a space in the wallpaper file path the script can't handle it properly. Putting double quotes around wallpaper path variables ensures correct command argument substitution and fixes this.