### PR TITLE
Make a copy of blurred image instead symlinking to it

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,30 +30,30 @@ if ! test -f ~/.bg.png; then
     fi
 fi
 
-SDDM_THEME_PATH=/usr/share/sddm/themes
-SDDM_THEME=$(cat /etc/sddm.conf | grep 'Current' | sed -E 's/.*=//')
+SDDM_THEME_NAME=$(cat /etc/sddm.conf | grep 'Current' | sed -E 's/.*=//')
+SDDM_THEME_PATH=/usr/share/sddm/themes/$SDDM_THEME_NAME
 
-if ! [ $SDDM_THEME ]; then
+if ! [ $SDDM_THEME_NAME ]; then
     echo No theme found in /etc/sddm.conf
     echo You can find all theme names by executing $ ls $SDDM_THEME_PATH
     while true; do
-        echo -n Please specify your theme name: ; read SDDM_THEME
-        if ! test -d $SDDM_THEME_PATH/$SDDM_THEME; then
-            echo No theme named $SDDM_THEME found at $SDDM_THEME_PATH/
+        echo -n Please specify your theme name: ; read SDDM_THEME_NAME
+        if ! test -d $SDDM_THEME_PATH/$SDDM_THEME_NAME; then
+            echo No theme named $SDDM_THEME_NAME found at $SDDM_THEME_PATH/
         else
             break
         fi
     done
 fi
 
-SDDM_THEME_PATH=$SDDM_THEME_PATH/$SDDM_THEME
-
-if ! test -f $SDDM_THEME_PATH/.bg.png; then
-    echo creating symlink to .bg.png in $SDDM_THEME_PATH
-    echo
-    sudo ln -sf ~/.bg.png $SDDM_THEME_PATH/.bg.png
+if test -f $SDDM_THEME_PATH/.bg.png; then
+    sudo rm $SDDM_THEME_PATH/.bg.png
 fi
-sudo chmod 777 ~/.bg.png
+
+echo copying .bg.png to $SDDM_THEME_PATH
+echo
+sudo cp ~/.bg.png $SDDM_THEME_PATH/.bg.png
+sudo chmod 777 $SDDM_THEME_PATH/.bg.png
 
 echo creating sddm config
 cat $SDDM_THEME_PATH/theme.conf.user | sed -E 's/background=.*/background=.bg.png/' | sed -E 's/type=.*/type=image/' >> /tmp/theme.conf.user

--- a/wpblur.sh
+++ b/wpblur.sh
@@ -5,9 +5,23 @@ if [ $(pidof -x wpblur.sh| wc -w) -gt 2 ]; then
     exit 1
 fi
 
+SDDM_THEME_NAME=$(cat /etc/sddm.conf | grep 'Current' | sed -E 's/.*=//')
+SDDM_THEME_PATH=/usr/share/sddm/themes/$SDDM_THEME_NAME
+
+if ! [ $SDDM_THEME_NAME ]; then
+cat <<EOF >> $HOME/.wpblur.log
+$(date)
+script terminated
+reason: can't detrminate current SDDM theme path:
+$SDDM_THEME_PATH/$SDDM_THEME_NAME/
+
+EOF
+fi
+
 while true; do
     inotifywait -q ~/.config/plasma-org.kde.plasma.desktop-appletsrc -e delete_self -e open | while read; do
         sleep 2
         convert "$(cat ~/.config/plasma-org.kde.plasma.desktop-appletsrc | grep -E "^Image=(file)?" | sed -E 's/Image=(file:\/\/)?//')" -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
+        cp ~/.bg.png $SDDM_THEME_PATH/.bg.png
     done
 done

--- a/wpblur.sh
+++ b/wpblur.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $(pidof -x wpblur.sh| wc -w) -gt 2 ]; then
+if [ $(pidof -x wpblur.sh | wc -w) -gt 2 ]; then
 	echo wpblur already running, exiting
     exit 1
 fi
@@ -16,12 +16,24 @@ reason: can't detrminate current SDDM theme path:
 $SDDM_THEME_PATH/$SDDM_THEME_NAME/
 
 EOF
+exit 1
 fi
 
 while true; do
     inotifywait -q ~/.config/plasma-org.kde.plasma.desktop-appletsrc -e delete_self -e open | while read; do
         sleep 2
         convert "$(cat ~/.config/plasma-org.kde.plasma.desktop-appletsrc | grep -E "^Image=(file)?" | sed -E 's/Image=(file:\/\/)?//')" -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
+        if test -w $SDDM_THEME_PATH/.bg.png; then
         cp ~/.bg.png $SDDM_THEME_PATH/.bg.png
+        else
+cat <<EOF >> $HOME/.wpblur.log
+$(date)
+script terminated
+reason: can't overwrite $SDDM_THEME_PATH/.bg.png
+check if file exists and have proper permissions.
+
+EOF
+exit 1
+        fi
     done
 done


### PR DESCRIPTION
According to #5 there can be a situation whenever SDDM can't access users `$HOME`.

Solution: instead of creating a symlink to `$HOME/.bg.png` copy it to SDDM theme directly. 

Cons:
Now blurring script will need to check sddm path every time. If the path changed it won't be able to copy a file. Now if any error occurs script will create `$HOME/.wpblur.log` file with Date and error message.