### PR TITLE
Safely obtain the wallpaper path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,13 +14,8 @@ if ! test -f "$BIN_PATH/convert" ; then
     exit
 fi
 
-if ! test -f "$BIN_PATH/journalctl" ; then
-    echo journalctl not found on your system, please use systemd.
-    exit
-fi
-
-qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript 'd = desktopForScreen(0); d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General"); print("cw=" + d.readConfig("Image"));'
-CURRENT_WP_PATH=$(journalctl -n 10 | grep -o 'cw=.*' | tail -n 1 | sed -E 's/cw=(file:\/\/)?//;s/"$//')
+qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript 'd = desktopForScreen(0); d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General"); d.writeGlobalConfig("mainwp", d.readConfig("Image"));'
+CURRENT_WP_PATH=$(cat ~/.config/plasma-org.kde.plasma.desktop-appletsrc | grep -E "^mainwp=(file)?" | sed -E 's/mainwp=(file:\/\/)?//')
 
 if ! test -f ~/.bg.png; then
     if [ "$CURRENT_WP_PATH" ]; then

--- a/wpblur.sh
+++ b/wpblur.sh
@@ -3,8 +3,8 @@
 function blur {
     echo "Blurring the background"
     sleep 2
-    qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript 'd = desktopForScreen(0); d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General"); print("cw=" + d.readConfig("Image"));'
-    CURRENT_WP_PATH=$(journalctl -n 10 | grep -o 'cw=.*' | tail -n 1 | sed -E 's/cw=(file:\/\/)?//;s/"$//')
+    qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript 'd = desktopForScreen(0); d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General"); d.writeGlobalConfig("mainwp", d.readConfig("Image"));'
+    CURRENT_WP_PATH=$(cat ~/.config/plasma-org.kde.plasma.desktop-appletsrc | grep -E "^mainwp=(file)?" | sed -E 's/mainwp=(file:\/\/)?//')
     convert "$CURRENT_WP_PATH" -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
     echo "Background blurring finished"
 }


### PR DESCRIPTION
The script is currently broken on Ubuntu because there is an issue with `journalctl` not registering evaluated Plasma Shell script's output. See https://github.com/andreyorst/kde_wallpaper_blur/issues/6#issuecomment-374876876.

This patch makes use and abuse of the `desktop-appletsrc` config file in order to safely obtain the wallpaper path. Abuse, because it'll be polluted with an additional line somewhere in the global config section, but I don't really think that's a huge drawback. Or maybe it is? You decide.