### PR TITLE
Remove redundancy across script files

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,20 +14,12 @@ if ! test -f "$BIN_PATH/convert" ; then
     exit
 fi
 
-curActivityId=$(qdbus org.kde.ActivityManager /ActivityManager/Activities CurrentActivity)
-while read containmentId; do
-    lastDesktop=$(kreadconfig5 --file ~/.config/plasma-org.kde.plasma.desktop-appletsrc --group Containments --group $containmentId --key lastScreen)
-    activityId=$(kreadconfig5 --file ~/.config/plasma-org.kde.plasma.desktop-appletsrc --group Containments --group $containmentId --key activityId)
-    if [[ $lastDesktop == "0" ]] && [[ $activityId == $curActivityId ]] ; then
-        CURRENT_WP_PATH=$(kreadconfig5 --file ~/.config/plasma-org.kde.plasma.desktop-appletsrc --group Containments --group $containmentId --group Wallpaper --group org.kde.image --group General --key Image | sed -E 's/(file:\/\/)?//')
-    fi
-done <<< "$(grep -e '\[Containments]\[[0-9]*]\[Wallpaper]\[org.kde.image]\[General]' ~/.config/plasma-org.kde.plasma.desktop-appletsrc | sed 's/\[Containments\]\[//;s/]\[Wallpaper]\[org.kde.image]\[General]//')"
-
 if ! test -f ~/.bg.png; then
+    CURRENT_WP_PATH=$(./wpblur.sh currentWpPath)
     if [ "$CURRENT_WP_PATH" ]; then
         echo blurring your current wallpaper
         echo
-        convert "$CURRENT_WP_PATH" -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
+        ./wpblur.sh blurWp "$CURRENT_WP_PATH"
         sleep 10
     else
         PROMPT=1

--- a/wpblur.sh
+++ b/wpblur.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-function blur {
-    echo "Blurring the background"
-    sleep 2
+function currentWpPath {
     curActivityId=$(qdbus org.kde.ActivityManager /ActivityManager/Activities CurrentActivity)
     while read containmentId; do 
         lastDesktop=$(kreadconfig5 --file ~/.config/plasma-org.kde.plasma.desktop-appletsrc --group Containments --group $containmentId --key lastScreen)
@@ -11,8 +9,19 @@ function blur {
             CURRENT_WP_PATH=$(kreadconfig5 --file ~/.config/plasma-org.kde.plasma.desktop-appletsrc --group Containments --group $containmentId --group Wallpaper --group org.kde.image --group General --key Image | sed -E 's/(file:\/\/)?//')
         fi
     done <<< "$(grep -e '\[Containments]\[[0-9]*]\[Wallpaper]\[org.kde.image]\[General]' ~/.config/plasma-org.kde.plasma.desktop-appletsrc | sed 's/\[Containments\]\[//;s/]\[Wallpaper]\[org.kde.image]\[General]//')" 
+    echo "$CURRENT_WP_PATH"
+}
+
+function blurWp {
+    CURRENT_WP_PATH="$1"
+    echo "Blurring the background"
     convert "$CURRENT_WP_PATH" -filter Gaussian -resize 5% -define filter:sigma=2.5 -resize 2000% -attenuate 0.2 +noise Gaussian ~/.bg.png
     echo "Background blurring finished"
+}
+
+function blur {
+    CURRENT_WP_PATH=$(currentWpPath)
+    blurWp "$CURRENT_WP_PATH"
 }
 
 if [ $(pidof -x wpblur.sh| wc -w) -gt 2 ]; then

--- a/wpblur.sh
+++ b/wpblur.sh
@@ -51,4 +51,8 @@ function run {
     sleep infinity
 }
 
-run
+if [ $# -eq 0 ]; then
+    run
+else
+    $1 $2
+fi


### PR DESCRIPTION
Instead of having the same code for getting the wallpaper path and for blurring it in both files, it might be better to split it into functions in `wpblur.sh` and just call those functions from `setup.sh`. The script is easier to maintain this way and if one wants to modify the implementation of the aforementioned actions, one has to do it only once in `wpblur.sh`, without duplicating the code in both files.